### PR TITLE
Try the 'trusty' build environment again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
-dist: trusty
+dist: xenial
 jdk:
   - openjdk7
   - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
-dist: precise
+dist: trusty
 jdk:
-  - oraclejdk7
+  - openjdk7
   - oraclejdk8
 before_script:
   sudo keytool -importcert -keystore $JAVA_HOME/jre/lib/security/cacerts -file betamax.pem -storepass changeit -noprompt


### PR DESCRIPTION
Doing this because precise (12.04) is end of life. We previously had troubles with openjdk7, which was the reason to why we used precise instead (to be able to use oraclejdk7). My hopes here are that openjdk7 has solved the issues we ran into.