### PR TITLE
Run Java 8 on the trusty build environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: java
-dist: precise
-jdk:
-  - oraclejdk7
-  - oraclejdk8
+matrix:
+  include:
+    - jdk: oraclejdk8
+    - jdk: oraclejdk7
+      dist: precise
 before_script:
   sudo keytool -importcert -keystore $JAVA_HOME/jre/lib/security/cacerts -file betamax.pem -storepass changeit -noprompt
 sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ matrix:
     - jdk: oraclejdk7
       dist: precise
       env:
-        - MAVEN_OPTS=-Dhttps.protocols=TLSv1.2
+        - JAVA_TOOL_OPTIONS=-Dhttps.protocols=TLSv1.2
 before_script:
   sudo keytool -importcert -keystore $JAVA_HOME/jre/lib/security/cacerts -file betamax.pem -storepass changeit -noprompt
 sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ matrix:
     - jdk: oraclejdk8
     - jdk: oraclejdk7
       dist: precise
+      env:
+        - MAVEN_OPTS=-Dhttps.protocols=TLSv1.2
 before_script:
   sudo keytool -importcert -keystore $JAVA_HOME/jre/lib/security/cacerts -file betamax.pem -storepass changeit -noprompt
 sudo: required


### PR DESCRIPTION
We have to keep running oraclejdk7 on the precise image if we don't want to resort to work-arounds, see https://github.com/travis-ci/travis-ci/issues/8503.

As mentioned in #38 the simplest solution is probably just to drop the Java 7 support, especially seeing since it went EoL in 2015.