### PR TITLE
Stop running Java 7 tests on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: java
-dist: precise
 jdk:
-  - oraclejdk7
   - oraclejdk8
 before_script:
   sudo keytool -importcert -keystore $JAVA_HOME/jre/lib/security/cacerts -file betamax.pem -storepass changeit -noprompt


### PR DESCRIPTION
Multiple reasons:

* Java 7 only works, somewhat (see below), in the precise environment. The precise build environment is deprecated by Tracis CI
* Java 7 went EoL in 2015
* I did, unsuccessful, attempts to get green Java 7 builds in #37 and #39

Close #38