### PR TITLE
Link to our new API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Twingly Search API Java [![GitHub Build Status](https://github.com/twingly/twingly-search-api-java/workflows/CI/badge.svg?branch=master)](https://github.com/twingly/twingly-search-api-java/actions)
 
-Java client for Twingly Search API (previously known as Twingly Analytics API). Twingly is a blog search service that provides a searchable API known as [Twingly Search API](https://developer.twingly.com/resources/search/).
+Java client for Twingly Search API (previously known as Twingly Analytics API). Twingly is a blog search service that provides a searchable API known as [Twingly Search API][Twingly Search API documentation].
 
 ## Installation
 
@@ -35,8 +35,6 @@ To learn more about the features of this client, check out the example code that
 
 To learn more about the capabilities of the API, please read the [Twingly Search API documentation].
 
-[Twingly Search API documentation]: https://developer.twingly.com/resources/search/
-
 ### API key from Java system properties
 
 Additionally, you can create Client object with API key from Java system properties (property name is `TWINGLY_SEARCH_KEY`):
@@ -66,9 +64,7 @@ Given exception hierarchy is now available:
           * TwinglySearchAuthenticationException - exception that happened due to Client Authentication problems
           * TwinglySEarchQueryException - exception that happened due to problems with Query
 
-Check documentation [Error paragraph][error] for additional information.
-
-[error]: https://developer.twingly.com/resources/search/#error
+Check [Twingly Search API documentation] for additional information about error codes.
 
 ## Requirements
 
@@ -178,6 +174,8 @@ This will save JAR file with all needed dependencies in `build/libs/` with `-all
 * Set `CHANGELOG_GITHUB_TOKEN` to a personal access token to increase your GitHub API rate limit
 * Generate the changelog
     * `github_changelog_generator`
+
+[Twingly Search API documentation]: https://app.twingly.com/blog_search?tab=documentation
 
 ## License
 

--- a/build.gradle
+++ b/build.gradle
@@ -155,7 +155,7 @@ uploadArchives {
                     name "twingly-search"
                     packaging "jar"
                     description "Client for Twingly Search API."
-                    url "https://developer.twingly.com/resources/search/"
+                    url "https://app.twingly.com/blog_search?tab=documentation"
 
                     scm {
                         connection "scm:git@github.com:twingly/twingly-search-api-java.git"

--- a/src/main/java/com/twingly/search/client/Client.java
+++ b/src/main/java/com/twingly/search/client/Client.java
@@ -8,7 +8,7 @@ import com.twingly.search.exception.TwinglySearchException;
 /**
  * Performs all network operations related to using Twingly Search API
  *
- * @see <a href="https://developer.twingly.com/resources/search-language/">Search Langunage</a>
+ * @see <a href="https://app.twingly.com/blog_search?tab=documentation">Search Langunage</a>
  * @see Query
  */
 public interface Client {

--- a/src/main/java/com/twingly/search/domain/Language.java
+++ b/src/main/java/com/twingly/search/domain/Language.java
@@ -3,7 +3,7 @@ package com.twingly.search.domain;
 /**
  * This enum contain all supported by Twingly languages
  *
- * @see <a href="https://developer.twingly.com/resources/search-language/#supported-languages">Supported languages</a>
+ * @see <a href="https://app.twingly.com/blog_search?tab=documentation">Supported languages</a>
  */
 public enum Language {
     /**

--- a/src/main/java/com/twingly/search/domain/Location.java
+++ b/src/main/java/com/twingly/search/domain/Location.java
@@ -3,7 +3,7 @@ package com.twingly.search.domain;
 /**
  * This enum contain all supported by Twingly locations
  *
- * @see <a href="https://developer.twingly.com/resources/search-language/#supported-locations">Supported locations</a>
+ * @see <a href="https://app.twingly.com/blog_search?tab=documentation">Supported locations</a>
  * @since 1.1.0
  */
 public enum Location {

--- a/src/main/java/com/twingly/search/domain/Post.java
+++ b/src/main/java/com/twingly/search/domain/Post.java
@@ -16,7 +16,7 @@ import java.math.BigDecimal;
 /**
  * This class represents Post entity from TwinglySearch API response.
  *
- * @see <a href="https://developer.twingly.com/resources/search/#response">Response documentation</a>
+ * @see <a href="https://app.twingly.com/blog_search?tab=documentation">Response documentation</a>
  */
 @XmlRootElement(name = "post")
 public class Post {
@@ -70,13 +70,13 @@ public class Post {
     /**
      * the blog's authority/influence.
      *
-     * @see <a href="https://developer.twingly.com/resources/ranking/#authority">Authority</a>
+     * @see <a href="https://app.twingly.com/blog_search?tab=documentation">Authority</a>
      */
     private int authority;
     /**
      * the rank of the blog, based on authority and language.
      *
-     * @see <a href="https://developer.twingly.com/resources/ranking/#blogrank">Blogrank</a>
+     * @see <a href="https://app.twingly.com/blog_search?tab=documentation">Blogrank</a>
      */
     private int blogRank;
     /**


### PR DESCRIPTION
As the old site, developer.twingly.com, has been shut down. The documentation for all of our APIs are now available (behind login) at https://app.twingly.com instead.

I didn't link to the specific documentation sections in the code, just so we don't need to update the links in case we restructure the documentation in the future.